### PR TITLE
在 URLNormalizer.php 實現 setCSVMapPath 介面

### DIFF
--- a/URLNormalizer.php
+++ b/URLNormalizer.php
@@ -2,6 +2,11 @@
 
 class URLNormalizer
 {
+
+    protected static $_csv_map_path = FALSE;
+
+    protected static $_csvmap = null;
+
     public static function replaceVar($str, $vars, $query)
     {
         return preg_replace_callback('/{\$([^}]*)}/', function($matches) use ($vars, $query) {
@@ -34,7 +39,10 @@ class URLNormalizer
         }
     }
 
-    protected static $_csvmap = null;
+    public static function setCSVMapPath($path)
+    {
+        self::$_csv_map_path = $path;
+    }
 
     public static function getCSVMap()
     {
@@ -42,7 +50,11 @@ class URLNormalizer
             return self::$_csvmap;
         }
 
-        $fp = fopen(__DIR__ . '/map.csv', 'r');
+        if (self::$_csv_map_path === FALSE) {
+            self::$_csv_map_path = __DIR__ . '/map.csv';
+        }
+
+        $fp = fopen(self::$_csv_map_path, 'r');
         $columns = fgetcsv($fp);
         $csvmap = array();
         while ($row = fgetcsv($fp)) {


### PR DESCRIPTION
在 url-normalizer.js 的 Javascript 函式庫中有類似的介面，只是把這個加到 PHP 函式庫中去。

用法︰

```
    <?php

    include('path/to/URLNormalizer.php');

    // 設定一個客製的 map.csv 檔
    URLNormalize::setCSVMapPath(
        __DIR__ . '/custom.map.csv');

    // 可以用囉！
    $url = 'http://some.foobar.com/some/path';
    URLNormalize::query($url);

    ?>
```
